### PR TITLE
Clean the attributes before getting defs

### DIFF
--- a/src/create/aws/create-tables/_create-table.js
+++ b/src/create/aws/create-tables/_create-table.js
@@ -32,7 +32,7 @@ module.exports = function _createTable(name, attr, callback) {
           function _createTable(callback) {
             dynamo.createTable({
               TableName,
-              AttributeDefinitions: getAttributeDefinitions(attr),
+              AttributeDefinitions: getAttributeDefinitions(clean(attr)),
               KeySchema: getKeySchema(attr, keys),
               ProvisionedThroughput: {
                 ReadCapacityUnits: 5,

--- a/src/sandbox/db/create-table/_create-table.js
+++ b/src/sandbox/db/create-table/_create-table.js
@@ -37,7 +37,7 @@ module.exports = function _createTable(name, attr, indexes, callback) {
         print.create('@tables create', name)
         var params = {
           TableName: name,
-          AttributeDefinitions: getAttributeDefinitions(attr),
+          AttributeDefinitions: getAttributeDefinitions(clean(attr)),
           KeySchema: getKeySchema(attr, keys),
           ProvisionedThroughput: {
             ReadCapacityUnits: 5,


### PR DESCRIPTION
This fixes an error where the `arc-sessions` tables are not created in DynamoDB due to `_ttl` being given an undefined Attribute Definition. Interestingly, this did not cause any issue in Dynalite but the fix also works in both places.