### PR TITLE
Fix for #89

### DIFF
--- a/src/util/init.js
+++ b/src/util/init.js
@@ -69,8 +69,10 @@ module.exports = function credentials(callback) {
   if (!process.env.AWS_PROFILE)
     err('missing AWS_PROFILE in environment')
 
-  let nodeMajorOk = Number(process.version.replace('v', '').split('.')[0]) >= 8
-  let nodeMinorOk =  Number(process.version.replace('v', '').split('.')[1]) >= 10
+  let nodeVersionArr = process.version.replace('v', '').split('.').map(Number);
+  let nodeMajorOk = nodeVersionArr[0] >= 8
+  let nodeMinorOk = nodeVersionArr[0] > 8 || nodeVersionArr[1] >= 10
+
   if (!(nodeMajorOk && nodeMinorOk))
     err(`Node@${process.version} is not valid; must be 8.10 or higher`)
 


### PR DESCRIPTION
Node version was incorrectly checked in util/init.js where both major
version and minor version needed to be bigger than 8.10. This prompted
the error "Error Node@v9.5.0 is not valid; must be 8.10 or higher"

I just fixed by testing for major being bigger than 8 before checking
minor.