### PR TITLE
Use PORT from environment

### DIFF
--- a/src/sandbox/cli.js
+++ b/src/sandbox/cli.js
@@ -4,14 +4,14 @@ var chalk = require('chalk')
 var start = require('./start')
 var noop = x=>!x
 
-inUse(3333, function _available(err, ok) {
+inUse(process.env.PORT, function _available(err, ok) {
   if (err) {
     console.log(chalk.bold.red(`Error`), chalk.white.bold(err.message))
     process.exit(1)
   }
   else if (ok) {
     console.log(chalk.bold.red(`Error`), chalk.white.bold(`.arc sandbox cannot start\n`))
-    console.log(`The address http://localhost:3333 is already in use.`)
+    console.log(`The address http://localhost:${process.env.PORT} is already in use.`)
     console.log('\n')
     process.exit(1)
   }

--- a/src/sandbox/env/_env-vars.js
+++ b/src/sandbox/env/_env-vars.js
@@ -10,6 +10,7 @@ module.exports = function _setupEnv(callback) {
   let raw = read(arcPath).toString()
   let arc = parse(raw)
   let name = arc.app[0]
+ 
 
   // populate ARC_APP_NAME (used by @architect/functions event.publish)
   process.env.ARC_APP_NAME = name
@@ -25,6 +26,11 @@ module.exports = function _setupEnv(callback) {
 
   if (process.env.NODE_ENV === 'production') {
     process.env.SESSION_TABLE_NAME = `${name}-production-arc-sessions`
+  }
+
+  // populate PORT (used by http server)
+  if (!process.env.PORT) {
+    process.env.PORT = `3333`
   }
 
   // interpolate arc-env

--- a/src/sandbox/env/_env-vars.js
+++ b/src/sandbox/env/_env-vars.js
@@ -10,7 +10,7 @@ module.exports = function _setupEnv(callback) {
   let raw = read(arcPath).toString()
   let arc = parse(raw)
   let name = arc.app[0]
- 
+
 
   // populate ARC_APP_NAME (used by @architect/functions event.publish)
   process.env.ARC_APP_NAME = name

--- a/src/sandbox/http/index.js
+++ b/src/sandbox/http/index.js
@@ -55,8 +55,7 @@ app.start = function start(callback) {
     app(req, res, finalhandler(req, res))
   })
 
-  // TODO make port configurable
-  server.listen(3333, callback)
+  server.listen(process.env.PORT, callback)
   return app
 }
 

--- a/src/sandbox/start.js
+++ b/src/sandbox/start.js
@@ -41,7 +41,7 @@ module.exports = function start(callback) {
       // vanilla af http server that mounts routes defined by .arc
       http.start(function() {
         let start = chalk.grey('\n', chalk.green.dim('✓'), 'Started HTTP "server" @ ')
-        let end = chalk.cyan.underline('http://localhost:3333')
+        let end = chalk.cyan.underline(`http://localhost:${process.env.PORT}`)
         console.log(`${start} ${end}`)
         callback()
       })

--- a/test/sandbox/00-html-test.js
+++ b/test/sandbox/00-html-test.js
@@ -7,6 +7,7 @@ var sandbox = require('../../src/sandbox').http
 var db = require('../../src/sandbox').db
 var client
 var server
+var port = process.env.PORT
 
 test('setup', t=> {
   t.plan(1)
@@ -38,15 +39,15 @@ test('setup db server', t=> {
 test('setup web server', t=> {
   t.plan(1)
   server = sandbox.start(function() {
-    t.ok(true, 'started server @ localhost:3333')
+    t.ok(true, `started server @ localhost:${port}`)
   })
 })
 
 test('can read /', t=> {
   t.plan(2)
   tiny.get({
-    url: 'http://localhost:3333/'
-  }, 
+    url: `http://localhost:${port}/`
+  },
   function _got(err, data) {
     if (err) {
       t.fail(err)
@@ -55,7 +56,7 @@ test('can read /', t=> {
     else {
       t.ok(true, 'got /')
       t.equals('hello world', data.body, 'is hello world')
-      console.log({data})    
+      console.log({data})
     }
   })
 })
@@ -64,8 +65,8 @@ test('can read /hello.css', t=> {
   t.plan(1)
     console.log(process.cwd())
   tiny.get({
-    url: 'http://localhost:3333/hello.css'
-  }, 
+    url: `http://localhost:${port}/hello.css`
+  },
   function _got(err, data) {
     if (err) {
       t.fail(err)
@@ -73,7 +74,7 @@ test('can read /hello.css', t=> {
     }
     else {
       t.ok(true, 'got /hello.css')
-      console.log({data})    
+      console.log({data})
     }
   })
 })

--- a/test/sandbox/01-json-test.js
+++ b/test/sandbox/01-json-test.js
@@ -3,20 +3,21 @@ var join = require('path').join
 var test = require('tape')
 var sandbox = require('../../src/sandbox')
 var end
+var port = process.env.PORT
 
 test('setup', t=> {
   t.plan(1)
   server = sandbox.start(function(close) {
     end = close
-    t.ok(true, 'started server @ localhost:3333')
+    t.ok(true, `started server @ localhost:${port}`)
   })
 })
 
 test('can read /api', t=> {
   t.plan(2)
   tiny.get({
-    url: 'http://localhost:3333/api'
-  }, 
+    url: `http://localhost:${port}/api`
+  },
   function _got(err, data) {
     if (err) {
       t.fail(err)
@@ -25,7 +26,7 @@ test('can read /api', t=> {
     else {
       t.ok(true, 'got /')
       t.equals('world', data.body.hello, 'is hello world')
-      console.log(data)    
+      console.log(data)
     }
   })
 })

--- a/test/sandbox/03-env-test.js
+++ b/test/sandbox/03-env-test.js
@@ -3,12 +3,13 @@ var join = require('path').join
 var test = require('tape')
 var sandbox = require('../../src/sandbox')
 var end
+var port = process.env.PORT
 
 test('setup', t=> {
   t.plan(1)
   server = sandbox.start(function(close) {
     end = close
-    t.ok(true, 'started server @ localhost:3333')
+    t.ok(true, `started server @ localhost:${port}`)
   })
 })
 
@@ -17,7 +18,7 @@ test('can read /api', t=> {
   t.plan(5)
   tiny.get({
     url: 'http://localhost:3333/api'
-  }, 
+  },
   function _got(err, data) {
     if (err) {
       t.fail(err)
@@ -29,7 +30,7 @@ test('can read /api', t=> {
       t.equals('1', data.body.envs.GLOBAL_ONE, 'is hello world')
       t.equals('too', data.body.envs.GLOBAL_TWO, 'is hello world')
       t.equals('http://localhost:3333', data.body.envs.GLOBAL_THREE, 'is hello world')
-      //console.log(data.body)    
+      //console.log(data.body)
     }
   })
 })*/


### PR DESCRIPTION
As mentioned in https://github.com/smallwins/begin-issues/issues/2 there are multiple ways of approaching having the server listening port be configurable. Here I just took the easiest approach which seemed to align with how some of the other environment variables was laid out.

I did manage to run the full test suite (because I didn't manage to set the full project up locally), but I ran the package with begin-functions-app, and it seemed to work fine.